### PR TITLE
#166265833 Integrate Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ cache:
     - "node_modules"
 after_script:
   - after-build --exit-code $TRAVIS_TEST_RESULT
+after_success: 
+  - "npm run coverage"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![Build Status](https://travis-ci.org/emp-daisy/HelloBooksLib.svg?branch=develop)](https://travis-ci.org/emp-daisy/HelloBooksLib)
+[![Coverage Status](https://coveralls.io/repos/github/emp-daisy/HelloBooksLib/badge.svg?branch=develop)](https://coveralls.io/github/emp-daisy/HelloBooksLib?branch=develop)
 
 ## Getting Started
 ---


### PR DESCRIPTION
### What does this PR do?
- This PR integrates code coverage service with coveralls
### Description of Task to be completed?
- Install coveralls
- Add hellobooks repo to coveralls
- Add coveralls badge to readMe file
- Add coverage script after success to travis.yml
### How should this be manually tested?
- Running `npm run coverage` on the command-line sends the test report to coveralls
### Any background context you want to provide?
- Jude had already written a coverage script so there was no need for me to add one.
### What are the relevant pivotal tracker stories?
- [#166265833](https://www.pivotaltracker.com/story/show/166265833)
### Screenshots (if appropriate)
![travis](https://user-images.githubusercontent.com/20531075/58551959-8b9eb600-8211-11e9-80f3-991c5f0c9fbe.PNG)
![package json](https://user-images.githubusercontent.com/20531075/58551974-92c5c400-8211-11e9-8e69-50f8c25a6983.PNG)
![covera](https://user-images.githubusercontent.com/20531075/58551981-99543b80-8211-11e9-83a5-c363c77e9a5b.PNG)
![cover](https://user-images.githubusercontent.com/20531075/58552884-c73a7f80-8213-11e9-95e5-e4d75794955e.PNG)
### Questions
- N/A

