### PR TITLE
feat(validation): write sign up validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2956,6 +2956,15 @@
         }
       }
     },
+    "express-validator": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-5.3.1.tgz",
+      "integrity": "sha512-g8xkipBF6VxHbO1+ksC7nxUU7+pWif0+OZXjZTybKJ/V0aTVhuCoHbyhIPgSYVldwQLocGExPtB2pE0DqK4jsw==",
+      "requires": {
+        "lodash": "^4.17.10",
+        "validator": "^10.4.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "debug": "^4.1.1",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
+    "express-validator": "^5.3.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",

--- a/server/middlewares/signupValidation.js
+++ b/server/middlewares/signupValidation.js
@@ -1,0 +1,50 @@
+import {check, validationResult} from 'express-validator/check';
+
+
+const signupValidate = [
+  check('firstName')
+    .not()
+    .isEmpty({ ignore_whitespace: true })
+    .withMessage('First Name should not be left empty: Please input firstName')
+    .isAlpha()
+    .trim()
+    .withMessage('first Name can only contain letters: Please remove invalid characters'),
+  check('lastName')
+    .not()
+    .isEmpty({ ignore_whitespace: true })
+    .withMessage('Last name should not be left empty: Please input lastName')
+    .isAlpha()
+    .trim()
+    .withMessage('Last name can ony contain letters: remove invalid characters'),
+  check('email')
+    .not()
+    .isEmpty({ ignore_whitespace: true })
+    .withMessage('Email should not be left empty: Please input email address')
+    .isEmail()
+    .trim()
+    .withMessage('Email is not valid: Please input a valid email address'),
+  check('password')
+    .not()
+    .isEmpty({ ignore_whitespace: true })
+    .withMessage('Password should not be empty: Please input password')
+    .trim()
+    .isLength({ min: 7 })
+    .withMessage('Password Length should be at least 8 Characters'),
+    
+  (req, res, next) => {
+    const errors = validationResult(req);
+    const errMessages = [];
+    if (!errors.isEmpty()) {
+      errors.array({ onlyFirstError: true }).forEach((err) => {
+        errMessages.push(err.msg);
+      });
+      return res.status(400).json({
+        status: 400,
+        error: errMessages,
+      });
+    }
+    return next();
+},
+]
+
+export default signupValidate;

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -1,8 +1,9 @@
 import express from 'express';
 import userController from '../controllers/userController';
+import signupValidate from '../middlewares/signupValidation';
 
 const userRoute = express.Router();
 
-userRoute.post('/signup', userController.signUp);
+userRoute.post('/signup',signupValidate, userController.signUp);
 
 export default userRoute;


### PR DESCRIPTION
### What does this PR do?
Add validation to the sign up endpoint
#### Description of Task to be completed?
When a user tries to sign up with the wrong or unsupported input format, the user should receive descriptive signup/Registration validation error(s)
#### How should this be manually tested?
>- Clone the repo
>- Run `npm run dev`
>-  Make a `POST` request with bad input format to localhost:6000/api/v1/auth/signup
#### Any background context you want to provide?
No
#### What are the relevant pivotal tracker stories?
[#166265842](https://www.pivotaltracker.com/story/show/166265842)
#### Screenshots (if appropriate)
![Screenshot 2019-05-31 at 11 41 25 AM](https://user-images.githubusercontent.com/29557902/58700962-840a1900-8399-11e9-8b7c-b9dc308cb1c9.png)
#### Questions: