### PR TITLE
#166266544 Add email signin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3047,6 +3047,15 @@
         }
       }
     },
+    "express-validator": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-5.3.1.tgz",
+      "integrity": "sha512-g8xkipBF6VxHbO1+ksC7nxUU7+pWif0+OZXjZTybKJ/V0aTVhuCoHbyhIPgSYVldwQLocGExPtB2pE0DqK4jsw==",
+      "requires": {
+        "lodash": "^4.17.10",
+        "validator": "^10.4.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3385,8 +3394,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3407,14 +3415,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3429,20 +3435,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3559,8 +3562,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3572,7 +3574,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3587,7 +3588,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3595,14 +3595,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3621,7 +3619,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3702,8 +3699,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3715,7 +3711,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3801,8 +3796,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3838,7 +3832,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3858,7 +3851,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3902,14 +3894,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "debug": "^4.1.1",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
+    "express-validator": "^5.3.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",

--- a/server/__test__/__snapshots__/user.spec.js.snap
+++ b/server/__test__/__snapshots__/user.spec.js.snap
@@ -61,6 +61,49 @@ Array [
 ]
 `;
 
+exports[`User tests test for email signin Should not sign in an unkown user 1`] = `
+Object {
+  "error": "Incorrect Login information",
+  "status": 401,
+}
+`;
+
+exports[`User tests test for email signin Should not sign in user with incorrect password 1`] = `
+Object {
+  "error": "Incorrect Login information",
+  "status": 401,
+}
+`;
+
+exports[`User tests test for email signin Should not sign in user with wrong email 1`] = `
+Object {
+  "error": Array [
+    "Email is not valid: Please input a valid email address",
+  ],
+  "status": 400,
+}
+`;
+
+exports[`User tests test for email signin Should not sign in with incomplete form data 1`] = `
+Object {
+  "error": Array [
+    "Email should not be left empty: Please input email address",
+    "Password should not be empty: Please input password",
+  ],
+  "status": 400,
+}
+`;
+
+exports[`User tests test for email signin Should sign in a user with complete form data 1`] = `
+Array [
+  "token",
+  "id",
+  "firstName",
+  "lastName",
+  "email",
+]
+`;
+
 exports[`User tests test for user signup Should not register a new user if the user already exists 1`] = `
 Object {
   "error": "email address exists already",

--- a/server/__test__/mock_data/mock_users.js
+++ b/server/__test__/mock_data/mock_users.js
@@ -1,0 +1,28 @@
+const mockUser = {
+  completeLoginData: {
+    email: 'testing1@example.com',
+    password: 'password'
+  },
+
+  incompleteLoginData: {
+    email: '',
+    password: ''
+  },
+
+  wrongEmail: {
+    email: 'wrongEmail@com',
+    password: 'password'
+  },
+
+  unknownUser: {
+    email: 'unknown_person@gmail.com',
+    password: 'password'
+  },
+
+  incorrectPassword: {
+    email: 'testing1@example.com',
+    password: 'randomword'
+  },
+}
+
+export default mockUser;

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -46,6 +46,31 @@ class UserController {
     }
   }
 
+  static async emailSignin(req, res) {
+    try {
+      const { email, password } = req.body;
+      const user = await models.Users.findOne({ where: { email } });
+      if (!user) return util.errorStatus(res, 401, 'Incorrect Login information');
+     
+      const result = await auth.comparePassword(password, user.password);
+
+      if (!result) return util.errorStatus(res, 401, 'Incorrect Login information');
+ 
+      const token = auth.generateToken(user.dataValues);
+
+      return util.successStatus(res, 200, 'Login successful', {
+        token,
+        id: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+      });
+
+    } catch (error) {
+      util.errorStatus(res, 500, 'Internal server Error');;
+    }
+  }
+  
   static async socialSignin(req, res) {
     let user;
     try {

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -1,0 +1,35 @@
+import {check, validationResult} from 'express-validator/check';
+import util from '../helpers/utilities';
+
+const validate = {
+  signin : [
+    check('email')
+      .not()
+      .isEmpty({ ignore_whitespace: true })
+      .withMessage('Email should not be left empty: Please input email address')
+      .isEmail()
+      .trim()
+      .withMessage('Email is not valid: Please input a valid email address'),
+    check('password')
+      .not()
+      .isEmpty({ ignore_whitespace: true })
+      .withMessage('Password should not be empty: Please input password')
+      .trim()
+      .isLength({ min: 7 })
+      .withMessage('Password Length should be at least 8 Characters'),
+      
+    (req, res, next) => {
+      const errors = validationResult(req);
+      const errMessages = [];
+      if (!errors.isEmpty()) {
+        errors.array({ onlyFirstError: true }).forEach((err) => {
+          errMessages.push(err.msg);
+        });
+        return util.errorStatus(res, 400, errMessages);
+      }
+      return next();
+  },
+  ]  
+}
+
+export default validate;

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -1,9 +1,11 @@
 import express from 'express';
 import UserController from '../controllers/userController';
+import Validate from '../middleware/validation';
 
 const userRoute = express.Router();
 
 userRoute.post('/signup', UserController.signUp);
+userRoute.post('/signin', Validate.signin, UserController.emailSignin);
 userRoute.get('/verifyEmail', UserController.verifyEmailLink);
 userRoute.post('/passwordreset', UserController.initiateReset);
 userRoute.get('/passwordreset/:id/:token', UserController.verifyResetLink);


### PR DESCRIPTION
### What does this PR do?
- POST /api/v1/auth/signin
- It creates a /auth/signin endpoint where users can sign in via email

#### Description of Task to be completed?
- Add /signin enpoint to routes
- Add validation middleware for user inputs
- Add signinController as route handler
- Get email, password from request body
- Query db for user
- Return response based on the query result

#### How should this be manually tested?
- Create a new user
- Test by signing in the user with their email and password

#### Any background context you want to provide?
- I went through @PelumiAlesh' s signup validation branch and applied his signup logic to my sign in endpoint since this endpoint will also need validations.

#### What are the relevant pivotal tracker stories?
[166266544](https://www.pivotaltracker.com/n/projects/2351121/stories/166266544)
#### Screenshots (if appropriate)
![postman](https://user-images.githubusercontent.com/20531075/58785167-47caf880-85e5-11e9-9711-3c2e08121f28.JPG)

#### Questions:    
N/A

[Delievers #166266544]