### PR TITLE
#166265910 See the estimated available date of a book

### DIFF
--- a/server/__test__/book.spec.js
+++ b/server/__test__/book.spec.js
@@ -724,6 +724,18 @@ describe('Books tests', () => {
           done();
       });
     });
+
+    it('Should not reserve a book if it has been borrowed', async done => {
+      server()
+      .post(`${url}/reserve?isbn=${ISBN}`)
+      .set('Authorization', `Bearer ${token}`)
+      .end((_err, res) => {
+        expect(res.statusCode).toEqual(400);
+        expect(res.body).toHaveProperty('error');
+        done();
+      });
+    });
+
     it('Should fail if no token is set', async done => {
       server()
       .post(`${url}/reserve?isbn=${ISBN}`)
@@ -740,7 +752,7 @@ describe('Books tests', () => {
         expect(res.statusCode).toEqual(400);
         done();
       })
-    })
+    });
   });
 
   describe('Check book reservation test', () => {

--- a/server/routes/bookRoute.js
+++ b/server/routes/bookRoute.js
@@ -45,6 +45,7 @@ bookRoute.post('/reserve',
   Authenticate.isLoggedIn,
   Authenticate.deleteReservedIfExpired,
   Validate.isbn,
+  Validate.borrowBook,
   Authenticate.isReserved,
   BookController.reserveBook
 );


### PR DESCRIPTION
#### What does this PR do?
Implement the feature to inform a user of the estimated availability date of a book that has been borrowed

#### Description of Task to be completed?
- add middleware to check if the book that a user wants to borrow has been borrowed and return the estimated availability date 

#### How should this be manually tested?
- checkout to ft/166265910/see-book-availbilty and start the dev server
- send a `POST` request to `/books/borrow` then a `POST` request to `/books/reserve` requesting for a book that has been borrowed `

#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
[#166265910](https://www.pivotaltracker.com/story/show/166265910)
#### Screenshots (if appropriate)
- None